### PR TITLE
Add types here from eth-utils

### DIFF
--- a/eth_typing/misc.py
+++ b/eth_typing/misc.py
@@ -5,7 +5,7 @@ from typing import (
 )
 
 Address = NewType('Address', bytes)  # for canonical Addresses
-BlockNumber = NewType('BlockNumber', int)
+BlockNumber = NewType('BlockNumber', int) 
 Hash32 = NewType('Hash32', bytes)
 HexAddress = NewType('HexAddress', str)  # for hex encoded addresses
 HexStr = NewType('HexStr', str)

--- a/eth_typing/misc.py
+++ b/eth_typing/misc.py
@@ -5,7 +5,7 @@ from typing import (
 )
 
 Address = NewType('Address', bytes)  # for canonical Addresses
-BlockNumber = NewType('BlockNumber', int) 
+BlockNumber = NewType('BlockNumber', int)
 Hash32 = NewType('Hash32', bytes)
 HexAddress = NewType('HexAddress', str)  # for hex encoded addresses
 HexStr = NewType('HexStr', str)

--- a/eth_typing/misc.py
+++ b/eth_typing/misc.py
@@ -1,7 +1,16 @@
 from typing import (
     NewType,
+    TypeVar,
+    Union,
 )
 
-Address = NewType('Address', bytes)
-Hash32 = NewType('Hash32', bytes)
+Address = NewType('Address', bytes)  # for canonical Addresses
 BlockNumber = NewType('BlockNumber', int)
+Hash32 = NewType('Hash32', bytes)
+HexAddress = NewType('HexAddress', str)  # for hex encoded addresses
+HexStr = NewType('HexStr', str)
+Primitives = Union[bytes, int, bool]  # for conversion utils
+
+ChecksumAddress = NewType('ChecksumAddress', HexAddress)  # for hex addresses with checksums
+
+AnyAddress = TypeVar('AnyAddress', Address, HexAddress, ChecksumAddress)


### PR DESCRIPTION
## What was wrong?
ETH types were being stored in `.misc` inside eth-utils so they have been moved here.

#### Cute Animal Picture

![image](https://user-images.githubusercontent.com/9753150/41479350-1d797f0c-7088-11e8-96b9-2940ef3d6b07.png)
