### PR TITLE
Enable discovery of type hints as per PEP561

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,7 @@ setup(
     zip_safe=False,
     keywords='ethereum',
     packages=find_packages(exclude=["tests", "tests.*"]),
+    package_data={'eth_typing': ['py.typed']},
     classifiers=[
         'Development Status :: 3 - Alpha',
         'Intended Audience :: Developers',


### PR DESCRIPTION
## What was wrong?

The `eth_typing` module was born to codify stronger type guarantees for things that previously could only expressed broadly.

Example: An API should only accept things of type `Hash32` instead of any `bytes`.

This worked fine for when we had this module as part of the `Trinity` code base. However, some of these types naturally spread across multiple code bases and hence we created a standalone repository (this one).

Unfortunately before [PEP561](https://www.python.org/dev/peps/pep-0561/) using type information from 3rd party libraries was pretty much useless and the only way to work around it was to setup stubs and make `mypy` aware of them.

Since we didn't have any stubs for `eth-typing`, ironically our effort to limit something as broadly defined as `bytes` now became `Any` (without us noticing since we don't have such strict `mypy` checks enabled for Trinity yet).

## How was it fixed?

Configure package to distribute type information to be picked up by mypy in packages using `eth-typing`.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://media0.giphy.com/media/103LdJoxGzv3Ik/giphy.gif)
