### PR TITLE
Add mypy checking to CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,9 @@ chains
 .pytest_cache
 .cache
 
+# mypy cache
+.mypy_cache
+
 # Test output logs
 logs
 ### JetBrains template

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import (
 
 extras_require = {
     'test': [
-        "pytest>=3.6,<3.7",
+        "pytest>=4.4,<4.5",
         "pytest-xdist",
         "tox>=2.9.1,<3",
     ],

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ extras_require = {
     'lint': [
         "flake8==3.4.1",
         "isort>=4.2.15,<5",
+        "mypy==0.701",
     ],
     'doc': [
         "Sphinx>=1.6.5,<2",

--- a/tox.ini
+++ b/tox.ini
@@ -38,5 +38,6 @@ whitelist_externals=make
 basepython=python
 extras=lint
 commands=
+    mypy eth_typing --strict --strict-equality
     flake8 {toxinidir}/eth_typing {toxinidir}/tests
     isort --recursive --check-only --diff {toxinidir}/eth_typing {toxinidir}/tests


### PR DESCRIPTION
## What was wrong?

Brain needs a warm up tasks after holidays. Also, project had no mypy CI check.

## How was it fixed?

- Added mypy run to CI
- upgraded pytest to `4.4` due to an incompatibility with more recent `pytest-xdist` version.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://best4bunny.com/wp/wp-content/uploads/2018/02/Best4bunny-food.jpg)
