### PR TITLE
Add `ConstantinopleFix` and `Istanbul` to ForkName

### DIFF
--- a/eth_typing/enums.py
+++ b/eth_typing/enums.py
@@ -6,3 +6,5 @@ class ForkName:
     Byzantium = 'Byzantium'
     Constantinople = 'Constantinople'
     Metropolis = 'Metropolis'
+    ConstantinopleFix = 'ConstantinopleFix'
+    Istanbul = 'Istanbul'


### PR DESCRIPTION
## What was wrong?

`ConstantinopleFix` and `Istanbul` were missing in ForkName

## How was it fixed?

Added `ConstantinopleFix` and `Istanbul` to ForkName

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://preview.redd.it/xwzg74yenms31.png?width=640&crop=smart&auto=webp&s=5cd5e63de983cf6aaa26f43adf739adde8c040fa)
