### PR TITLE
Make description look nice on pypi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,17 +36,20 @@ extras_require['dev'] = (
     extras_require['doc']
 )
 
+with open('./README.md') as readme:
+    long_description = readme.read()
+
 setup(
     name='eth-typing',
     # *IMPORTANT*: Don't manually change the version here. Use `make bump`, as described in readme
     version='2.2.0',
     description="""eth-typing: Common type annotations for ethereum python packages""",
-    long_description_markdown_filename='README.md',
+    long_description=long_description,
+    long_description_content_type='text/markdown',
     author='The eth-typing contributors',
     author_email='eth-typing@ethereum.org',
     url='https://github.com/ethereum/eth-typing',
     include_package_data=True,
-    setup_requires=['setuptools-markdown'],
     python_requires='>=3.5, <4',
     extras_require=extras_require,
     py_modules=['eth_typing'],


### PR DESCRIPTION
## What was wrong?

The markdown description isn't rendered correctly on pypi.

![image](https://user-images.githubusercontent.com/521109/67933964-2f2c3200-fbc7-11e9-81e2-6303f41a48e3.png)


## How was it fixed?

Use `long_description` and `long_description_content_type` as we did in a bunch of other repos to [cure this](https://github.com/ethereum/lahja/commit/c16be248b2a05af279f6b9ce923686e37894cce6)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.pinimg.com/originals/8c/aa/32/8caa32a5573196205080a93fc275dfff.jpg)
