### PR TITLE
Update HexAddres type from str to HexStr

### DIFF
--- a/eth_typing/evm.py
+++ b/eth_typing/evm.py
@@ -4,11 +4,15 @@ from typing import (
     Union,
 )
 
+from .encoding import (
+    HexStr,
+)
+
 Hash32 = NewType('Hash32', bytes)
 BlockNumber = NewType('BlockNumber', int)
 BlockIdentifier = Union[BlockNumber, Hash32]
 
 Address = NewType('Address', bytes)
-HexAddress = NewType('HexAddress', str)
+HexAddress = NewType('HexAddress', HexStr)
 ChecksumAddress = NewType('ChecksumAddress', HexAddress)
 AnyAddress = TypeVar('AnyAddress', Address, HexAddress, ChecksumAddress)


### PR DESCRIPTION
## What was wrong?
`HexAddress` type is better suited to be a subtype from `HexStr`

#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/9753150/69329848-1a850c00-0c52-11ea-9460-c75cce3c784c.png)

