### PR TITLE
Add new type for BLS private key

### DIFF
--- a/eth_typing/__init__.py
+++ b/eth_typing/__init__.py
@@ -3,6 +3,7 @@ from .abi import (  # noqa: F401
     TypeStr,
 )
 from .bls import (  # noqa: F401
+    BLSPrivateKey,
     BLSPubkey,
     BLSSignature,
 )

--- a/eth_typing/bls.py
+++ b/eth_typing/bls.py
@@ -3,4 +3,5 @@ from typing import (
 )
 
 BLSPubkey = NewType('BLSPubkey', bytes)  # bytes48
+BLSPrivateKey = NewType('BLSPrivateKey', int)
 BLSSignature = NewType('BLSSignature', bytes)  # bytes96


### PR DESCRIPTION
## What was wrong?

Various parts of the eth2.0 ecosystem will reference a BLS private key, e.g. a validator needing to sign a block for broadcast.

## How was it fixed?

Adding a `NewType` for a `BLSPrivateKey`

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://static.parade.com/wp-content/uploads/2018/06/Fiona-the-Hippo-Book-FTR.jpg)
