### PR TITLE
Add NodeID type

### DIFF
--- a/docs/types.rst
+++ b/docs/types.rst
@@ -49,6 +49,19 @@ Class that contains the different names used to represent hard forks on the Ethe
         Constantinople = 'Constantinople'
         Metropolis = 'Metropolis'
 
+Discovery
+---------
+
+NodeID
+~~~~~~
+
+A 32-byte identifier for a node in the Discovery DHT
+
+.. code-block:: python
+
+    NodeID = NewType('NodeID', bytes)
+
+
 EthPM
 -----
 

--- a/eth_typing/__init__.py
+++ b/eth_typing/__init__.py
@@ -6,6 +6,9 @@ from .bls import (  # noqa: F401
     BLSPubkey,
     BLSSignature,
 )
+from .discovery import (  # noqa: F401
+    NodeID,
+)
 from .encoding import (  # noqa: F401
     HexStr,
     Primitives,

--- a/eth_typing/discovery.py
+++ b/eth_typing/discovery.py
@@ -1,4 +1,5 @@
-from typing import NewType
-
+from typing import (
+    NewType,
+)
 
 NodeID = NewType("NodeID", bytes)

--- a/eth_typing/discovery.py
+++ b/eth_typing/discovery.py
@@ -1,0 +1,4 @@
+from typing import NewType
+
+
+NodeID = NewType("NodeID", bytes)

--- a/setup.py
+++ b/setup.py
@@ -12,9 +12,9 @@ extras_require = {
         "tox>=2.9.1,<3",
     ],
     'lint': [
-        "flake8==3.4.1",
+        "flake8==3.8.3",
         "isort>=4.2.15,<5",
-        "mypy==0.701",
+        "mypy==0.782",
         "pydocstyle>=3.0.0,<4",
     ],
     'doc': [

--- a/tox.ini
+++ b/tox.ini
@@ -39,7 +39,7 @@ whitelist_externals=make
 basepython=python
 extras=lint
 commands=
-    mypy -p {toxinidir}/eth_typing --config-file {toxinidir}/mypy.ini
+    mypy -p eth_typing --config-file {toxinidir}/mypy.ini
     flake8 {toxinidir}/eth_typing {toxinidir}/tests
     isort --recursive --check-only --diff {toxinidir}/eth_typing {toxinidir}/tests
     pydocstyle {toxinidir}/eth_typing {toxinidir}/tests


### PR DESCRIPTION
## What was wrong?

After pulling the `eth-enr` library out we need a common type for `NodeID` across repositories.

## How was it fixed?

Added a `NewType("NodeID", bytes)`

#### Cute Animal Picture

![t5pzs](https://user-images.githubusercontent.com/824194/92025945-7c17f200-ed1d-11ea-85f0-f6e58641e02d.jpg)

