### PR TITLE
Add Berlin, London, and ArrowGlacier to ForkName enum

### DIFF
--- a/eth_typing/enums.py
+++ b/eth_typing/enums.py
@@ -8,3 +8,6 @@ class ForkName:
     Metropolis = 'Metropolis'
     ConstantinopleFix = 'ConstantinopleFix'
     Istanbul = 'Istanbul'
+    Berlin = 'Berlin'
+    London = 'London'
+    ArrowGlacier = 'ArrowGlacier'


### PR DESCRIPTION
## What was wrong?
Needed to add the new Hard Fork names to eth-typing.


## How was it fixed?

Added them!

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://www.rd.com/wp-content/uploads/2021/03/GettyImages-1133605325-scaled-e1617227898456.jpg)
