### PR TITLE
Add Python 3.8-3.10 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,13 +39,13 @@ jobs:
   doctest:
     <<: *common
     docker:
-      - image: circleci/python:3.6
+      - image: circleci/python:3.8
         environment:
           TOXENV: doctest
   lint:
     <<: *common
     docker:
-      - image: circleci/python:3.6
+      - image: circleci/python:3.8
         environment:
           TOXENV: lint
   py36-core:
@@ -60,6 +60,12 @@ jobs:
       - image: circleci/python:3.7
         environment:
           TOXENV: py37-core
+  py38-core:
+    <<: *common
+    docker:
+      - image: circleci/python:3.8
+        environment:
+          TOXENV: py38-core
   pypy3-core:
     <<: *common
     docker:
@@ -74,4 +80,5 @@ workflows:
       - lint
       - py36-core
       - py37-core
+      - py38-core
       - pypy3-core

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,6 +66,12 @@ jobs:
       - image: circleci/python:3.8
         environment:
           TOXENV: py38-core
+  py39-core:
+    <<: *common
+    docker:
+      - image: circleci/python:3.9
+        environment:
+          TOXENV: py39-core
   pypy3-core:
     <<: *common
     docker:
@@ -81,4 +87,5 @@ workflows:
       - py36-core
       - py37-core
       - py38-core
+      - py39-core
       - pypy3-core

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,6 +72,12 @@ jobs:
       - image: circleci/python:3.9
         environment:
           TOXENV: py39-core
+  py310-core:
+    <<: *common
+    docker:
+      - image: circleci/python:3.10
+        environment:
+          TOXENV: py310-core
   pypy3-core:
     <<: *common
     docker:
@@ -88,4 +94,5 @@ workflows:
       - py37-core
       - py38-core
       - py39-core
+      - py310-core
       - pypy3-core

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,5 @@
 [pytest]
 addopts= -v --showlocals --durations 10
-python_paths= .
 xfail_strict=true
 
 [pytest-watch]

--- a/setup.py
+++ b/setup.py
@@ -69,6 +69,7 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: Implementation :: PyPy',
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(
     author_email='snakecharmers@ethereum.org',
     url='https://github.com/ethereum/eth-typing',
     include_package_data=True,
-    python_requires='>=3.6, <4',
+    python_requires='>=3.6, <3.11',
     extras_require=extras_require,
     py_modules=['eth_typing'],
     license="MIT",
@@ -71,6 +71,7 @@ setup(
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: Implementation :: PyPy',
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import (
 
 extras_require = {
     'test': [
-        "pytest>=4.4,<4.5",
+        "pytest>=6.2.5,<7",
         "pytest-xdist",
         "tox>=2.9.1,<3",
     ],

--- a/setup.py
+++ b/setup.py
@@ -70,6 +70,7 @@ setup(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: Implementation :: PyPy',
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist=
-    py{35,36,37,38,py3}-core
+    py{35,36,37,38,39,py3}-core
     lint
     doctest
 
@@ -29,6 +29,7 @@ basepython =
     py36: python3.6
     py37: python3.7
     py38: python3.8
+    py39: python3.9
     pypy3: pypy3
 extras=
     test

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist=
-    py{35,36,37,38,39,py3}-core
+    py{35,36,37,38,39,310,py3}-core
     lint
     doctest
 
@@ -30,6 +30,7 @@ basepython =
     py37: python3.7
     py38: python3.8
     py39: python3.9
+    py310: python3.10
     pypy3: pypy3
 extras=
     test

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist=
-    py{36,37,py3}-core
+    py{35,36,37,38,py3}-core
     lint
     doctest
 
@@ -28,6 +28,7 @@ basepython =
     doctest: python
     py36: python3.6
     py37: python3.7
+    py38: python3.8
     pypy3: pypy3
 extras=
     test


### PR DESCRIPTION
** I branched off of the python 3.5 removal branch, so that should get merged first.

## What was wrong?

eth-typing needed some more python versions! 


## How was it fixed?

Added tests against python 3.8-3.10. For python 3.10 support, I had to bump pytest to >=6.2.5, and the python_path removal was because a deprecation warning from pytest was getting triggered. 

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://vetstreet-brightspot.s3.amazonaws.com/84/e1/2a42eb4547bfa2d690f5556e8bbe/buschgardensaadvark630aa030813.jpg)
