### PR TITLE
Correct the tox path

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ common: &common
         command: pip install --user tox
     - run:
         name: run tox
-        command: ~/.local/bin/tox -r
+        command: python -m tox -r
     - save_cache:
         paths:
           - .hypothesis

--- a/newsfragments/32.misc.rst
+++ b/newsfragments/32.misc.rst
@@ -1,0 +1,1 @@
+Use new circleci images


### PR DESCRIPTION
## What was wrong?
All tests are failing on master because tox can't be found in the new images 😵 


## How was it fixed?

corrected how tox is run

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/eth-typing/blob/master/newsfragments/README.md)
- [x] Add entry to the [release notes](https://github.com/ethereum/eth-typing/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://static.boredpanda.com/blog/wp-content/uploads/2017/05/cute-happy-gecko-with-toy-kohaku-fb.png)
