### PR TITLE
Set the upper cap on Python version to 4.0

### DIFF
--- a/newsfragments/37.bugfix.rst
+++ b/newsfragments/37.bugfix.rst
@@ -1,0 +1,1 @@
+Pin Python version to <4 instead of <3.11

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(
     author_email='snakecharmers@ethereum.org',
     url='https://github.com/ethereum/eth-typing',
     include_package_data=True,
-    python_requires='>=3.6, <3.11',
+    python_requires='>=3.6, <4',
     extras_require=extras_require,
     py_modules=['eth_typing'],
     license="MIT",


### PR DESCRIPTION
## What was wrong?

- `eth-typing`, seemingly the only one of the `eth-*` family of packages, has the cap on Python version set to `<3.11`. `eth-account`, `eth-utils`, `eth-abi` have it at `<4`. Unless there is something special about `eth-typing` that I am missing, it would be more consistent to set its cap to `<4` as well.
- A cap on minor Python version creates problems with dependency resolvers, since any user of the library has to also set the same upper cap to make the resolution work, thus propagating this decision.
- A minor release of Python is very unlikely to break something in an at least occasionally maintained package, since deprecations are rare, and each is announced several minor versions before it goes in effect.

## How was it fixed?

Upper cap on Python set to `<4`.

Note: it seems that the cap was introduced in https://github.com/ethereum/eth-typing/commit/b5e23be20a27dba1612eafac52d9f3ab265326e3, for an unspecified reason.
