### PR TITLE
bugfix: ``Merge`` -> ``Paris`` renaming for ForkName enum

### DIFF
--- a/eth_typing/enums.py
+++ b/eth_typing/enums.py
@@ -12,4 +12,4 @@ class ForkName:
     London = 'London'
     ArrowGlacier = 'ArrowGlacier'
     GrayGlacier = 'GrayGlacier'
-    Merge = 'Merge'
+    Paris = 'Paris'

--- a/newsfragments/38.bugfix.rst
+++ b/newsfragments/38.bugfix.rst
@@ -1,0 +1,1 @@
+Rename ``Merge`` to ``Paris`` in ``ForkNameEnum``


### PR DESCRIPTION
## What was wrong?

``Merge`` isn't really the fork name, even though `ethereum/tests` uses it as the name for the `Network`. We should use the appropriate name in `ForkNameEnum` for the execution layer fork name.

## How was it fixed?

Rename ``Merge`` to ``Paris``

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/eth-typing/blob/master/newsfragments/README.md)
- [x] Add entry to the [release notes](https://github.com/ethereum/eth-typing/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![GOPR4248](https://user-images.githubusercontent.com/3532824/190248347-fb4f1c78-b8d9-4966-9310-23eb738f5e3e.JPG)
