### PR TITLE
Py311 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,6 +72,13 @@ jobs:
       - image: cimg/python:3.10
         environment:
           TOXENV: py310-core
+  py311-core:
+    <<: *common
+    docker:
+      - image: cimg/python:3.11
+        environment:
+          TOXENV: py311-core
+
   pypy3-core:
     <<: *common
     docker:
@@ -88,4 +95,5 @@ workflows:
       - py38-core
       - py39-core
       - py310-core
+      - py311-core
       - pypy3-core

--- a/newsfragments/40.feature.rst
+++ b/newsfragments/40.feature.rst
@@ -1,0 +1,1 @@
+Add support for python ``3.11``.

--- a/setup.py
+++ b/setup.py
@@ -72,6 +72,7 @@ setup(
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: Implementation :: PyPy',
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist=
-    py{37,38,39,310,py3}-core
+    py{37,38,39,310,311,py3}-core
     lint
     docs
 
@@ -30,6 +30,7 @@ basepython =
     py38: python3.8
     py39: python3.9
     py310: python3.10
+    py311: python3.11
     pypy3: pypy3
 extras=
     test


### PR DESCRIPTION
## What was wrong?

Needs python 3.11 support

## How was it fixed?

- Cherry picked commits from PR #29 and finalized py311 support

### To-Do

- [x] Clean up commit history
- [x] Add entry to the [release notes](https://github.com/ethereum/eth-typing/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fi.pinimg.com%2Foriginals%2F1d%2Fe1%2F94%2F1de19422ac82ef0fcda348040902be59.jpg&f=1&nofb=1&ipt=eb1e3e3a90ffbed0e39cb95d89b43457b5ae612d67f8a035571e8db0219fbb0d&ipo=images)
