### PR TITLE
Bump ``mypy`` version

### DIFF
--- a/newsfragments/41.internal.rst
+++ b/newsfragments/41.internal.rst
@@ -1,0 +1,1 @@
+Bump ``mypy`` version to ``0.910`` to avoid issues installing the "[dev]" extra on Python 3.10. Update test suite to require installing the full dependency suite to help catch these errors.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ showcontent = true
 
 [[tool.towncrier.type]]
 directory = "internal"
-name = "Internal Changes - for <PROJECT_NAME> Contributors"
+name = "Internal Changes - for eth-typing Contributors"
 showcontent = true
 
 [[tool.towncrier.type]]

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ extras_require = {
     'lint': [
         "flake8==3.8.3",
         "isort>=4.2.15,<5",
-        "mypy==0.782",
+        "mypy==0.910",
         "pydocstyle>=3.0.0,<4",
     ],
     'doc': [

--- a/tox.ini
+++ b/tox.ini
@@ -33,7 +33,7 @@ basepython =
     py311: python3.11
     pypy3: pypy3
 extras=
-    test
+    dev
     docs: doc
 allowlist_externals=make
 


### PR DESCRIPTION
## What was wrong?

- ``mypy`` version was installing an older version of ``typed-ast`` causing issues for the ``[dev]`` install extra on python 3.10

## How was it fixed?

- Bump ``mypy`` version to ``0.910``
- Install the full dependency suite for the core tests so we can catch these sorts of issues in the future
- Fix a copy + paste blip from the template project in the `internal` newsfragment description

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/eth-typing/blob/master/newsfragments/README.md)
- [x] Add entry to the [release notes](https://github.com/ethereum/eth-typing/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![20230307_125845](https://user-images.githubusercontent.com/3532824/223540635-cf1584c3-249b-455e-9b6d-fa30132ddc65.jpg)
