### PR TITLE
bump docs dependencies, remove unused

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,6 @@
+version: 2
+
+python:
+  install:
+  - requirements: requirements-docs.txt
+

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -38,6 +38,7 @@ extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.doctest',
     'sphinx.ext.intersphinx',
+    'sphinx_rtd_theme',
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/newsfragments/43.internal.rst
+++ b/newsfragments/43.internal.rst
@@ -1,0 +1,1 @@
+remove unused docs deps, bump version of remaining

--- a/setup.py
+++ b/setup.py
@@ -18,8 +18,8 @@ extras_require = {
         "pydocstyle>=3.0.0,<4",
     ],
     'doc': [
-        "sphinx>=4.2.0,<5",
-        "sphinx_rtd_theme>=0.1.9",
+        "sphinx>=5.0.0",
+        "sphinx_rtd_theme>=1.0.0",
         "towncrier>=21,<22",
     ],
     'dev': [


### PR DESCRIPTION
## What was wrong?

Docs dependencies can be bumped and unnecessary ones removed

## How was it fixed?

Bumped and removed

### To-Do

- [x] Add entry to the [release notes](https://github.com/ethereum/eth-typing/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![image](https://user-images.githubusercontent.com/5199899/227634354-bc955444-b182-4253-9b87-2ca03cee8ed9.png)
