### PR TITLE
Add "Cancun" fork to ``ForkName``

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,9 @@ common: &common
           - cache-v1-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}
     - run:
         name: install dependencies
-        command: python -m pip install --user tox
+        command: |
+          python -m pip install --upgrade pip
+          python -m pip install tox
     - run:
         name: run tox
         command: python -m tox -r
@@ -50,7 +52,9 @@ windows_steps: &windows_steps
           - cache-v1-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}
     - run:
         name: install dependencies
-        command: python -m pip install --user tox
+        command: |
+          python -m pip install --upgrade pip
+          python -m pip install tox
     - run:
         name: run tox
         command: python -m tox -r

--- a/eth_typing/enums.py
+++ b/eth_typing/enums.py
@@ -14,3 +14,4 @@ class ForkName:
     GrayGlacier = "GrayGlacier"
     Paris = "Paris"
     Shanghai = "Shanghai"
+    Cancun = "Cancun"

--- a/newsfragments/45.feature.rst
+++ b/newsfragments/45.feature.rst
@@ -1,0 +1,1 @@
+Add ``Cancun`` to ``ForkName`` enum.

--- a/newsfragments/45.internal.rst
+++ b/newsfragments/45.internal.rst
@@ -1,0 +1,1 @@
+For CircleCI builds, update ``pip`` and pip install ``tox`` under sys instead of ``--user`` to avoid ``virtualenv`` versioning issues.


### PR DESCRIPTION
### What was wrong?

- `Cancun` fork name missing from `ForkName` enum

### How was it fixed?

- Add it

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/eth-typing/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis[-->]()](https://wanderingourworld.com/wp-content/uploads/2022/09/Sea-turtle-iStock-597934500.jpg)