### PR TITLE
Include tests in dist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,8 @@
 include LICENSE
 include README.md
 
+recursive-include tests *
+
 global-include *.pyi
 
 recursive-exclude * __pycache__

--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ notes: check-bump
 	make build-docs
 	git commit -m "Compile release notes"
 
-release: check-bump clean
+release: check-bump test clean
 	# require that you be on a branch that's linked to upstream/master
 	git status -s -b | head -1 | grep "\.\.upstream/master"
 	# verify that docs build correctly

--- a/newsfragments/46.internal.rst
+++ b/newsfragments/46.internal.rst
@@ -1,0 +1,1 @@
+Add the tests/ directory to the distributed tarball


### PR DESCRIPTION
### What was wrong?
We've had some requests to add the `tests/` directory to the `tar.gz` file

Closes #8

### How was it fixed?

Added `tests` to the MANIFEST, and ran `make dist`. Also added tests to the release command, because if we're going to put those up there, I'd like to be sure they pass.

### Todo:
- [x] Clean up commit history

- [x] Add or update documentation related to these changes

- [x] Add entry to the [release notes](https://github.com/ethereum/eth-typing/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://st4.depositphotos.com/7402484/31036/i/1600/depositphotos_310364244-stock-photo-cute-fat-animal-marmot-sitting.jpg)