### PR TITLE
Extend and more properly define typing for BlockIdentifier

### DIFF
--- a/eth_typing/evm.py
+++ b/eth_typing/evm.py
@@ -4,13 +4,18 @@ from typing import (
     Union,
 )
 
+from typing_extensions import (
+    Literal,
+)
+
 from .encoding import (
     HexStr,
 )
 
 Hash32 = NewType("Hash32", bytes)
 BlockNumber = NewType("BlockNumber", int)
-BlockIdentifier = Union[BlockNumber, Hash32]
+BlockParams = Literal["latest", "earliest", "pending", "safe", "finalized"]
+BlockIdentifier = Union[BlockParams, BlockNumber, Hash32, HexStr, int]
 
 Address = NewType("Address", bytes)
 HexAddress = NewType("HexAddress", HexStr)

--- a/newsfragments/47.feature.rst
+++ b/newsfragments/47.feature.rst
@@ -1,0 +1,1 @@
+Borrowing from the typing in web3.py, open up ``BlockIdentifier`` to include ``BlockParams`` (e.g. "latest", "finalized", etc..) as well as other valid values.

--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,10 @@ setup(
     author_email="snakecharmers@ethereum.org",
     url="https://github.com/ethereum/eth-typing",
     include_package_data=True,
+    install_requires=[
+        # remove typing_extensions after python_requires>=3.8
+        "typing-extensions>=4.0.1",
+    ],
     python_requires=">=3.7.2, <4",
     extras_require=extras_require,
     py_modules=["eth_typing"],


### PR DESCRIPTION
### What was wrong?

- `BlockIdentifier` does not cover all possible cases, such as `BlockParams`

### How was it fixed?

- Borrowing from the typing used in web3.py, where it has worked quite well, ``BlockIdentifer`` needed some modernizing in this library that would be nice to use across other libraries. eth-tester could benefit once type hinting is introduced there.

### Todo:
- [x] Clean up commit history
- [x] Add entry to the [release notes](https://github.com/ethereum/eth-typing/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![20230628_113301](https://github.com/ethereum/eth-typing/assets/3532824/9b12b379-126f-4870-b4f3-a32b94d58982)
