### PR TITLE
Fix setuptools to support __version__

### DIFF
--- a/eth_typing/__init__.py
+++ b/eth_typing/__init__.py
@@ -1,9 +1,13 @@
 try:
-    from importlib.metadata import version as __version
+    from importlib.metadata import (
+        version as __version,
+    )
 except ImportError:
     # TODO: remove once Python 3.7 is no longer supported
     def __version(package_name: str) -> str:  # type: ignore
-        from pkg_resources import get_distribution
+        from pkg_resources import (
+            get_distribution,
+        )
 
         return get_distribution(package_name).version
 

--- a/newsfragments/52.internal.rst
+++ b/newsfragments/52.internal.rst
@@ -1,0 +1,1 @@
+Add ``types-setuptools`` to support pkg_resources and __version__

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ extras_require = {
     "test": [
         "pytest>=7.0.0",
         "pytest-xdist>=2.4.0",
+        "types-setuptools",
     ],
     "lint": [
         "flake8==6.0.0",  # flake8 claims semver but adds new warnings at minor releases, leave it pinned.
@@ -17,6 +18,7 @@ extras_require = {
         "mypy==0.971",  # mypy does not follow semver, leave it pinned.
         "pydocstyle>=6.0.0",
         "black>=23",
+        "types-setuptools",
     ],
     "docs": [
         "sphinx>=5.0.0",


### PR DESCRIPTION
### What was wrong?
Added `__version__` to init file but now the build fails.

Related to Issue #
Closes #

### How was it fixed?
* Add types-setuptools

### Todo:
- [x] Clean up commit history

- [x] Add or update documentation related to these changes

- [x] Add entry to the [release notes](https://github.com/ethereum/eth-typing/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://api.time.com/wp-content/uploads/2015/08/pandas-china-debut.jpg)