### PR TITLE
Bump version: 3.5.1 (Revert Bump version: 3.5.1 -> 3.5.2)

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.5.2
+current_version = 3.5.1
 commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(-(?P<stage>[^.]*)\.(?P<devnum>\d+))?

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,6 @@ extras_require = {
     "test": [
         "pytest>=7.0.0",
         "pytest-xdist>=2.4.0",
-        "types-setuptools",
     ],
     "lint": [
         "flake8==6.0.0",  # flake8 claims semver but adds new warnings at minor releases, leave it pinned.

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ with open("./README.md") as readme:
 setup(
     name="eth-typing",
     # *IMPORTANT*: Don't manually change the version here. Use `make bump`, as described in readme
-    version="3.5.2",
+    version="3.5.1",
     description="""eth-typing: Common type annotations for ethereum python packages""",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
### What was wrong?
3.5.1 was never published to pypi due to a build error. Now that the error is fixed, we would prefer to publish version 3.5.1 for continuity.

### How was it fixed?
Revert the version to 3.5.1 and clean up tags.

Once merged clean up tags by, running `git tag -d v3.5.2` and `git push upstream --delete v3.5.2`.

### Todo:
- [X] Clean up commit history

- [X] Add or update documentation related to these changes

- [ ] Add entry to the [release notes](https://github.com/ethereum/eth-typing/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()