### PR TITLE
fix toml bools and add version test

### DIFF
--- a/newsfragments/56.internal.rst
+++ b/newsfragments/56.internal.rst
@@ -1,0 +1,1 @@
+Fixed booleans in ``pyproject.toml`` and added a test for the presence of the ``eth_typing.__version__`` attribute

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,32 +1,32 @@
 [tool.autoflake]
-remove_all_unused_imports = "True"
+remove_all_unused_imports = true
 exclude = "__init__.py"
 
 [tool.isort]
-combine_as_imports = "True"
+combine_as_imports = true
 extra_standard_library = "pytest"
 force_grid_wrap = 1
-force_sort_within_sections = "True"
+force_sort_within_sections = true
 known_third_party = "hypothesis,pytest"
 known_first_party = "eth_typing"
 multi_line_output = 3
 profile = "black"
 
 [tool.mypy]
-check_untyped_defs = "True"
-disallow_incomplete_defs = "True"
-disallow_untyped_defs = "True"
-disallow_any_generics = "True"
-disallow_untyped_calls = "True"
-disallow_untyped_decorators = "True"
-disallow_subclassing_any = "True"
-ignore_missing_imports = "True"
-strict_optional = "True"
-strict_equality = "True"
-warn_redundant_casts = "True"
-warn_return_any = "True"
-warn_unused_configs = "True"
-warn_unused_ignores = "True"
+check_untyped_defs = true
+disallow_incomplete_defs = true
+disallow_untyped_defs = true
+disallow_any_generics = true
+disallow_untyped_calls = true
+disallow_untyped_decorators = true
+disallow_subclassing_any = true
+ignore_missing_imports = true
+strict_optional = true
+strict_equality = true
+warn_redundant_casts = true
+warn_return_any = true
+warn_unused_configs = true
+warn_unused_ignores = true
 
 
 [tool.pydocstyle]
@@ -63,7 +63,7 @@ add-ignore = "D200,D203,D204,D205,D212,D302,D400,D401,D412,D415"
 
 [tool.pytest.ini_options]
 addopts = "-v --showlocals --durations 10"
-xfail_strict = "True"
+xfail_strict = true
 log_format = "%(levelname)8s  %(asctime)s  %(filename)20s  %(message)s"
 log_date_format = "%m-%d %H:%M:%S"
 

--- a/tests/core/test_import.py
+++ b/tests/core/test_import.py
@@ -1,2 +1,4 @@
 def test_import():
-    import eth_typing  # noqa: F401
+    import eth_typing
+
+    assert isinstance(eth_typing.__version__, str)


### PR DESCRIPTION
### What was wrong?

Some bools in `pyproject.toml` the wrong type - changed `"True"` to `true`.
Added a test to make sure the `__version__` attribute is available for the lib.

### Todo:

- [x] Clean up commit history

- [x] Add or update documentation related to these changes

- [x] Add entry to the [release notes](https://github.com/ethereum/eth-typing/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/ethereum/eth-typing/assets/5199899/43e3cbd5-5f8f-4665-9245-7b3a6da85004)
