### PR TITLE
remove types related to deprecated EthPM

### DIFF
--- a/docs/eth_typing.rst
+++ b/docs/eth_typing.rst
@@ -90,27 +90,6 @@ A 32-byte identifier for a node in the Discovery DHT
     NodeID = NewType('NodeID', bytes)
 
 
-EthPM
------
-
-ContractName
-~~~~~~~~~~~~
-
-Any string conforming to the regular expression ``[a-zA-Z][a-zA-Z0-9_]{0,255}``.
-
-.. code-block:: python
-
-    ContractName = NewType('ContractName', str)
-
-URI
-~~~
-
-Any string that represents a URI.
-
-.. code-block:: python
-
-    URI = NewType('URI', str)
-
 EVM
 ---
 

--- a/eth_typing/__init__.py
+++ b/eth_typing/__init__.py
@@ -21,11 +21,6 @@ from .encoding import (
 from .enums import (
     ForkName,
 )
-from .ethpm import (
-    URI,
-    ContractName,
-    Manifest,
-)
 from .evm import (
     Address,
     AnyAddress,
@@ -50,9 +45,6 @@ __all__ = (
     "Primitives",
     "ForkName",
     "ChainId",
-    "URI",
-    "ContractName",
-    "Manifest",
     "Address",
     "AnyAddress",
     "BlockIdentifier",

--- a/eth_typing/ethpm.py
+++ b/eth_typing/ethpm.py
@@ -1,9 +1,0 @@
-from typing import (
-    Any,
-    Dict,
-    NewType,
-)
-
-ContractName = NewType("ContractName", str)
-Manifest = NewType("Manifest", Dict[str, Any])
-URI = NewType("URI", str)

--- a/newsfragments/60.removal.rst
+++ b/newsfragments/60.removal.rst
@@ -1,0 +1,1 @@
+Remove types related to the EthPM module which has been removed from ``web3.py``


### PR DESCRIPTION
### What was wrong?

The EthPM module is removed in `web3.py v7` Removing related types here.

### How was it fixed?

### Todo:

- [x] Clean up commit history

- [x] Add or update documentation related to these changes

- [x] Add entry to the [release notes](https://github.com/ethereum/eth-typing/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/ethereum/eth-typing/assets/5199899/91ee3889-1541-405d-b872-2f2539bd0db6)
