### PR TITLE
Patch to add EthPM types back

### DIFF
--- a/docs/eth_typing.rst
+++ b/docs/eth_typing.rst
@@ -76,6 +76,27 @@ A 32-byte identifier for a node in the Discovery DHT
     NodeID = NewType('NodeID', bytes)
 
 
+EthPM
+-----
+
+ContractName
+~~~~~~~~~~~~
+
+Any string conforming to the regular expression ``[a-zA-Z][a-zA-Z0-9_]{0,255}``.
+
+.. code-block:: python
+
+    ContractName = NewType('ContractName', str)
+
+URI
+~~~
+
+Any string that represents a URI.
+
+.. code-block:: python
+
+    URI = NewType('URI', str)
+
 EVM
 ---
 

--- a/eth_typing/__init__.py
+++ b/eth_typing/__init__.py
@@ -32,6 +32,11 @@ from .encoding import (
 from .enums import (
     ForkName,
 )
+from .ethpm import (
+    URI,
+    ContractName,
+    Manifest,
+)
 from .evm import (
     Address,
     AnyAddress,
@@ -72,6 +77,9 @@ __all__ = (
     "Primitives",
     "ForkName",
     "ChainId",
+    "URI",
+    "ContractName",
+    "Manifest",
     "Address",
     "AnyAddress",
     "BlockIdentifier",

--- a/eth_typing/__init__.py
+++ b/eth_typing/__init__.py
@@ -51,7 +51,6 @@ from .exceptions import (
     ValidationError,
 )
 from .networks import (
-    URI,
     ChainId,
 )
 
@@ -87,7 +86,6 @@ __all__ = (
     "ChecksumAddress",
     "Hash32",
     "HexAddress",
-    "URI",
     "ValidationError",
     "MismatchedABI",
 )

--- a/eth_typing/ethpm.py
+++ b/eth_typing/ethpm.py
@@ -1,0 +1,9 @@
+from typing import (
+    Any,
+    Dict,
+    NewType,
+)
+
+ContractName = NewType("ContractName", str)
+Manifest = NewType("Manifest", Dict[str, Any])
+URI = NewType("URI", str)

--- a/eth_typing/networks.py
+++ b/eth_typing/networks.py
@@ -1,12 +1,6 @@
 from enum import (
     IntEnum,
 )
-from typing import (
-    NewType,
-)
-
-URI = NewType("URI", str)
-"""Any string that represents a URI."""
 
 
 class ChainId(IntEnum):

--- a/newsfragments/64.bugfix.rst
+++ b/newsfragments/64.bugfix.rst
@@ -1,0 +1,1 @@
+Put back types used for `EthPM`: `ContractName`, `Manifest`, and `URI`.


### PR DESCRIPTION
### What was wrong?
Types were removed (`Manifest` and `ContractName`) and `URI` was moved. Patching these back in to fix dependencies.

### How was it fixed?

This reverts changes made in 18e27da2d569b5aa1954912339ba4d7d70fc8b1d and part of https://github.com/ethereum/eth-typing/pull/61/files#diff-a5b9bc039309b9ea14ed2c69bb763a20a7afc06eab848f377490c4b5d5e49f12R4

### Todo:

- [X] Clean up commit history

- [X] Add or update documentation related to these changes

- [X] Add entry to the [release notes](https://github.com/ethereum/eth-typing/blob/main/newsfragments/README.md)

#### Cute Animal Picture
<img width="703" alt="Screen Shot 2024-04-16 at 12 46 37 PM" src="https://github.com/ethereum/eth-typing/assets/435903/0a6af821-bd31-490f-9e15-b439872a9b40">

