### PR TITLE
Optional attributes for `ABIComponent` type

### DIFF
--- a/eth_typing/abi.py
+++ b/eth_typing/abi.py
@@ -8,6 +8,7 @@ from typing import (
 )
 
 from typing_extensions import (
+    NotRequired,
     deprecated,
 )
 
@@ -59,12 +60,12 @@ class ABIComponent(TypedDict):
     TypedDict representing an `ABIElement` component.
     """
 
-    components: Sequence["ABIComponent"]
-    """List of nested `ABI` components for ABI types."""
     name: str
     """Name of the component."""
     type: str
     """Type of the component."""
+    components: NotRequired[Sequence["ABIComponent"]]
+    """List of nested `ABI` components for ABI types."""
 
 
 class ABIComponentIndexed(ABIComponent):
@@ -76,19 +77,19 @@ class ABIComponentIndexed(ABIComponent):
     """If True, component can be used as a topic filter."""
 
 
-class ABIEvent(TypedDict, total=False):
+class ABIEvent(TypedDict):
     """
     TypedDict to represent the `ABI` for an event.
     """
 
-    anonymous: bool
-    """If True, event is anonymous. Cannot filter the event by name."""
-    inputs: Sequence["ABIComponent"]
-    """Input components for the event."""
     name: str
     """Event name identifier."""
     type: Literal["event"]
     """Event ABI type."""
+    anonymous: NotRequired[bool]
+    """If True, event is anonymous. Cannot filter the event by name."""
+    inputs: NotRequired[Sequence["ABIComponent"]]
+    """Input components for the event."""
 
 
 @deprecated(ABI_COMPONENT_DEPRECATION_MSG.format("ABIFunctionComponent"))
@@ -142,33 +143,33 @@ class ABIFunctionType(TypedDict, total=False):
     """
 
 
-class ABIFunction(ABIFunctionType, total=False):
+class ABIFunction(ABIFunctionType):
     """
     TypedDict representing the `ABI` for a function.
     """
 
     type: Literal["function"]
     """Type of the function."""
-    inputs: Sequence["ABIComponent"]
-    """Function input components."""
     name: str
     """Name of the function."""
-    outputs: Sequence["ABIComponent"]
+    inputs: NotRequired[Sequence["ABIComponent"]]
+    """Function input components."""
+    outputs: NotRequired[Sequence["ABIComponent"]]
     """Function output components."""
 
 
-class ABIConstructor(ABIFunctionType, total=False):
+class ABIConstructor(ABIFunctionType):
     """
     TypedDict representing the `ABI` for a constructor function.
     """
 
     type: Literal["constructor"]
     """Type of the constructor function."""
-    inputs: Sequence["ABIComponent"]
+    inputs: NotRequired[Sequence["ABIComponent"]]
     """Function input components."""
 
 
-class ABIFallback(ABIFunctionType, total=False):
+class ABIFallback(ABIFunctionType):
     """
     TypedDict representing the `ABI` for a fallback function.
     """
@@ -177,7 +178,7 @@ class ABIFallback(ABIFunctionType, total=False):
     """Type of the fallback function."""
 
 
-class ABIReceive(ABIFunctionType, total=False):
+class ABIReceive(ABIFunctionType):
     """
     TypedDict representing the `ABI` for a receive function.
     """
@@ -186,7 +187,7 @@ class ABIReceive(ABIFunctionType, total=False):
     """Type of the receive function."""
 
 
-class ABIFunctionInfo(TypedDict, total=False):
+class ABIFunctionInfo(TypedDict):
     """
     TypedDict to represent an `ABIFunction` with the function selector and
     corresponding arguments.
@@ -200,17 +201,17 @@ class ABIFunctionInfo(TypedDict, total=False):
     """Function input components."""
 
 
-class ABIError(TypedDict, total=False):
+class ABIError(TypedDict):
     """
     TypedDict representing the `ABI` for an error.
     """
 
     type: Literal["error"]
     """Type of the error."""
-    inputs: Sequence["ABIComponent"]
-    """Error input components."""
     name: str
     """Name of the error."""
+    inputs: NotRequired[Sequence["ABIComponent"]]
+    """Error input components."""
 
 
 ABIElement = Union[

--- a/newsfragments/76.feature.rst
+++ b/newsfragments/76.feature.rst
@@ -1,0 +1,9 @@
+Mark ABI types with optional attributes.
+
+* ``ABIFunction`` requires ``type`` and ``name`` but ``inputs`` and ``outputs`` are optional.
+* ``ABIEvent`` requires ``type`` and ``name`` but ``inputs`` and ``anonymous`` are optional.
+* All attributes of ``ABIFunctionInfo`` are required.
+* ``ABIFallback`` and ``ABIReceive`` now require the ``type`` attribute.
+* ``ABIConstructor`` requires a ``type`` but ``inputs`` are optional.
+* ``ABIError`` requires ``type`` and ``name`` but ``inputs`` is optional.
+* ``ABIComponent`` requires ``type`` and ``name`` but ``components`` may be omitted so that ``inputs`` may use either ``primitive`` or ``tuple`` types. (`#76 <https://github.com/ethereum/eth-typing/issues/76>`__)


### PR DESCRIPTION
### What was wrong?
The `components` attribute may not be present in all subtypes of `ABIElement`.

`ABIElement` subtypes, such as `ABIEvent` or `ABIFunction` may not require a `components` attribute for all inputs. The `components` attribute must be optional to accommodate TypedDicts of the form:

```python
    abi_function = {
        "inputs": [{"name": "_arg0", "type": "uint256"}],
        "name": "logTwoEvents",
        "stateMutability": "nonpayable",
        "type": "function",
    }
```

Related to Issue https://github.com/ethereum/web3.py/issues/3036

### How was it fixed?

`total=False` on the `ABIComponent` type makes all attributes optional, so instead using `NotRequired` to denote specific attributes as optional. 

`components` can now be omitted when using `ABIComponent`.

### Todo:

- [x] Clean up commit history

- [x] Add or update documentation related to these changes

- [x] Add entry to the [release notes](https://github.com/ethereum/eth-typing/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![](https://i.ytimg.com/vi/40py9hD6t1g/maxresdefault.jpg)
