### PR TITLE
Add new ABI types to `ABIFunctionInfo` typing

### DIFF
--- a/eth_typing/__init__.py
+++ b/eth_typing/__init__.py
@@ -4,6 +4,7 @@ from importlib.metadata import (
 
 from .abi import (
     ABI,
+    ABICallable,
     ABIComponent,
     ABIComponentIndexed,
     ABIConstructor,
@@ -61,6 +62,7 @@ from .networks import (
 
 __all__ = (
     "ABI",
+    "ABICallable",
     "ABIComponent",
     "ABIComponentIndexed",
     "ABIConstructor",

--- a/eth_typing/abi.py
+++ b/eth_typing/abi.py
@@ -200,13 +200,16 @@ class ABIError(TypedDict):
     """Error input components."""
 
 
+ABICallable = Union[ABIFunction, ABIConstructor, ABIFallback, ABIReceive]
+
+
 class ABIFunctionInfo(TypedDict):
     """
-    TypedDict to represent an `ABIFunction` with the function selector and
-    corresponding arguments.
+    TypedDict to represent properties of an `ABIFunction`, including the function
+    selector and arguments.
     """
 
-    abi: Union[ABIFunction, ABIError, ABIFallback, ABIReceive]
+    abi: ABICallable
     """ABI for the function interface."""
     selector: HexStr
     """Solidity Function selector sighash."""
@@ -214,9 +217,7 @@ class ABIFunctionInfo(TypedDict):
     """Function input components."""
 
 
-ABIElement = Union[
-    ABIFunction, ABIConstructor, ABIFallback, ABIReceive, ABIEvent, ABIError
-]
+ABIElement = Union[ABICallable, ABIEvent, ABIError]
 """Base type for `ABIFunction` and `ABIEvent` types."""
 ABI = Sequence[ABIElement]
 """

--- a/eth_typing/abi.py
+++ b/eth_typing/abi.py
@@ -187,20 +187,6 @@ class ABIReceive(ABIFunctionType):
     """Type of the receive function."""
 
 
-class ABIFunctionInfo(TypedDict):
-    """
-    TypedDict to represent an `ABIFunction` with the function selector and
-    corresponding arguments.
-    """
-
-    abi: ABIFunction
-    """ABI for the function interface."""
-    selector: HexStr
-    """Solidity Function selector sighash."""
-    arguments: Tuple[Any, ...]
-    """Function input components."""
-
-
 class ABIError(TypedDict):
     """
     TypedDict representing the `ABI` for an error.
@@ -212,6 +198,20 @@ class ABIError(TypedDict):
     """Name of the error."""
     inputs: NotRequired[Sequence["ABIComponent"]]
     """Error input components."""
+
+
+class ABIFunctionInfo(TypedDict):
+    """
+    TypedDict to represent an `ABIFunction` with the function selector and
+    corresponding arguments.
+    """
+
+    abi: Union[ABIFunction, ABIError, ABIFallback, ABIReceive]
+    """ABI for the function interface."""
+    selector: HexStr
+    """Solidity Function selector sighash."""
+    arguments: Tuple[Any, ...]
+    """Function input components."""
 
 
 ABIElement = Union[

--- a/newsfragments/77.feature.rst
+++ b/newsfragments/77.feature.rst
@@ -1,0 +1,1 @@
+Added ``ABIError``, ``ABIFallback`` and ``ABIReceive`` types to ``ABIFunctionInfo.abi`` types. ``ABICallable`` is now a type alias for ``Union[ABIFunctionInfo, ABIError, ABIFallback, ABIReceive]``.


### PR DESCRIPTION
### What was wrong?

`get_function_info` web3 abi utility should allow all function types to be returned in `ABIFunctionInfo`. Currently only supports getting `ABIFunction` types, but it is apparent the function also must allow returning ``ABIError``, ``ABIFallback`` and ``ABIReceive`` types.

Related to:
https://github.com/ethereum/web3.py/pull/3408

See also:
https://github.com/ethereum/web3.py/issues/3036

### How was it fixed?
Added ``ABIError``, ``ABIFallback`` and ``ABIReceive`` types to ``ABIFunctionInfo`` type.

Also adds a ``ABICallable`` type to alias `Union[ABIFunction, ABIConstructor, ABIFallback, ABIReceive]`

### Todo:

- [x] Clean up commit history

- [x] Add or update documentation related to these changes

- [x] Add entry to the [release notes](https://github.com/ethereum/eth-typing/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://thumbs.dreamstime.com/b/calendar-illustration-snake-wrapped-light-symbolizing-year-glowing-golden-radiance-cute-autumn-sparkling-305954187.jpg)
