### PR TITLE
bump typing_extensions requirement

### DIFF
--- a/newsfragments/80.bugfix.rst
+++ b/newsfragments/80.bugfix.rst
@@ -1,0 +1,1 @@
+Update ``typing_extensions`` to ``4.5.0`` which supposrts ``deprecated`` decorator.

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
     url="https://github.com/ethereum/eth-typing",
     include_package_data=True,
     install_requires=[
-        "typing_extensions>=4.0.0",
+        "typing_extensions>=4.5.0",
     ],
     python_requires=">=3.8, <4",
     extras_require=extras_require,


### PR DESCRIPTION
### What was wrong?

Related to Issue #NA
latest version imports deprecated from typing_extensions.

typing_extensions adds deprecated type in commit: 673e5ce (jan 3 2023)
First version on pypi after jan 3 is 4.5.0 feb 15 2023.
in previous versions the deprecated type does not exist resulting in import errors
Closes #

### How was it fixed?
bump typing_extensions required version.


#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://files.oaiusercontent.com/file-YV4NMQm6NiijJ9J64M0j5yAR?se=2024-06-11T14%3A02%3A52Z&sp=r&sv=2023-11-03&sr=b&rscc=max-age%3D31536000%2C%20immutable&rscd=attachment%3B%20filename%3Da2c07f71-945d-4385-8ee1-2559357d3769.webp&sig=gLK69i7yLT4zrzJk9uN537abjIVGivGoXMXFQggK5R8%3D)
