### PR TITLE
Autodoc for `eth-typing` modules

### DIFF
--- a/docs/eth_typing.rst
+++ b/docs/eth_typing.rst
@@ -16,165 +16,50 @@ Application Binary Interface
     :members:
     :undoc-members:
 
-Enumerables
------------
+BLS
+---
 
-ForkName
-~~~~~~~~
-
-Class that contains the different names used to represent hard forks on the Ethereum network.
-
-.. code-block:: python
-
-    class ForkName:
-        Frontier = 'Frontier'
-        Homestead = 'Homestead'
-        EIP150 = 'EIP150'
-        EIP158 = 'EIP158'
-        Byzantium = 'Byzantium'
-        Constantinople = 'Constantinople'
-        Metropolis = 'Metropolis'
-
-
-ChainId
-~~~~~~~
-
-`IntEnum` class defining EVM-compatible network name enums as their respective chain id `int` values.
-
-To learn more about chain ids, see `CAIP-2`_ for details.
-
-.. _CAIP-2: https://github.com/ChainAgnostic/CAIPs/blob/main/CAIPs/caip-2.md
-
-The list of chain ids is available from the `ethereum-lists/chains`_ repository.
-
-.. _ethereum-lists/chains: https://github.com/ethereum-lists/chains
-
-.. code-block:: python
-
-    class ChainId(IntEnum):
-        # L1 networks
-        ETH = 1
-        EXP = 2
-        ROP = 3
-        RIN = 4
-        GOR = 5
-        # L2 networks
-        OETH = 10
-        GNO = 100
-
-Networks
---------
-
-URI
-~~~
-
-Any string that represents a URI.
-
-.. code-block:: python
-
-    URI = NewType('URI', str)
-
+.. automodule:: eth_typing.bls
+    :members:
+    :undoc-members:
 
 Discovery
 ---------
 
-NodeID
-~~~~~~
+.. automodule:: eth_typing.discovery
+    :members:
+    :undoc-members:
 
-A 32-byte identifier for a node in the Discovery DHT
+Enumerables
+-----------
 
-.. code-block:: python
+.. automodule:: eth_typing.enums
+    :members:
+    :undoc-members:
 
-    NodeID = NewType('NodeID', bytes)
+EthPM
+-----
 
+.. automodule:: eth_typing.ethpm
+    :members:
+    :undoc-members:
 
 EVM
 ---
 
-Address
-~~~~~~~
+.. automodule:: eth_typing.evm
+    :members:
+    :undoc-members:
 
-Any bytestring representing a canonical address.
+Exceptions
+----------
 
-.. code-block:: python
+.. automodule:: eth_typing.exceptions
+    :members:
+    :undoc-members:
 
-    Address = NewType('Address', bytes)
+Networks
+--------
 
-HexAddress
-~~~~~~~~~~
-
-Any HexStr_ representing a hex encoded address.
-
-.. code-block:: python
-
-    HexAddress = NewType('HexAddress', HexStr)
-
-ChecksumAddress
-~~~~~~~~~~~~~~~
-
-Any HexAddress_ that is formatted according to ERC55_.
-
-.. _ERC55: https://github.com/ethereum/EIPs/issues/55
-
-.. code-block:: python
-
-    ChecksumAddress = NewType('ChecksumAddress', HexAddress)
-
-AnyAddress
-~~~~~~~~~~
-
-Any of Address_, HexAddress_, ChecksumAddress_.
-
-.. code-block:: python
-
-    AnyAddress = TypeVar('AnyAddress', Address, HexAddress, ChecksumAddress)
-
-Hash32
-~~~~~~
-
-Any 32 byte hash.
-
-.. code-block:: python
-
-    Hash32 = NewType('Hash32', bytes)
-
-BlockNumber
-~~~~~~~~~~~
-
-Any integer that represents a valid block number on a chain.
-
-.. code-block:: python
-
-    BlockNumber = NewType('BlockNumber', int)
-
-BlockIdentifier
-~~~~~~~~~~~~~~~
-
-Either a 32 byte hash or an integer block number
-
-.. code-block:: python
-
-    BlockIdentifier = Union[Hash32, BlockNumber]
-
-Encodings
----------
-
-HexStr
-~~~~~~
-
-Any string that is hex encoded.
-
-.. code-block:: python
-
-    HexStr = NewType('HexStr', str)
-
-Primitives
-~~~~~~~~~~
-
-Any of `bytes`, `int`, or `bool` used as the `Primitive` arg for conversion utils in ETH-Utils_.
-
-.. _ETH-Utils: https://github.com/ethereum/eth-utils/
-
-.. code-block:: python
-
-    Primitives = Union[bytes, int, bool]
+.. automodule:: eth_typing.networks
+    :members:

--- a/docs/eth_typing.rst
+++ b/docs/eth_typing.rst
@@ -30,17 +30,17 @@ Discovery
     :members:
     :undoc-members:
 
-Enumerables
------------
+Encoding
+--------
 
-.. automodule:: eth_typing.enums
+.. automodule:: eth_typing.encoding
     :members:
     :undoc-members:
 
-EthPM
+Enums
 -----
 
-.. automodule:: eth_typing.ethpm
+.. automodule:: eth_typing.enums
     :members:
     :undoc-members:
 
@@ -57,6 +57,7 @@ Exceptions
 .. automodule:: eth_typing.exceptions
     :members:
     :undoc-members:
+
 
 Networks
 --------

--- a/eth_typing/abi.py
+++ b/eth_typing/abi.py
@@ -1,3 +1,7 @@
+"""
+Types for Contract ABIs and related components.
+"""
+
 from typing import (
     Any,
     Literal,

--- a/eth_typing/bls.py
+++ b/eth_typing/bls.py
@@ -1,7 +1,20 @@
+"""
+Types used for BLS Signatures.
+"""
+
 from typing import (
     NewType,
 )
 
-BLSPubkey = NewType("BLSPubkey", bytes)  # bytes48
+BLSPubkey = NewType("BLSPubkey", bytes)
+"""
+A BLS public key that is 48 bytes in length.
+"""
 BLSPrivateKey = NewType("BLSPrivateKey", int)
-BLSSignature = NewType("BLSSignature", bytes)  # bytes96
+"""
+A BLS private key integer value.
+"""
+BLSSignature = NewType("BLSSignature", bytes)
+"""
+A BLS signature that is 96 bytes in length.
+"""

--- a/eth_typing/discovery.py
+++ b/eth_typing/discovery.py
@@ -3,3 +3,12 @@ from typing import (
 )
 
 NodeID = NewType("NodeID", bytes)
+r"""
+A 32-byte identifier for a node in the Discovery DHT
+
+.. doctest::
+
+    >>> from eth_typing import NodeID
+    >>> NodeID(b'\x01' * 32)
+    b'\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01'
+"""

--- a/eth_typing/discovery.py
+++ b/eth_typing/discovery.py
@@ -1,10 +1,14 @@
+"""
+Types for the Discovery Protocol.
+"""
+
 from typing import (
     NewType,
 )
 
 NodeID = NewType("NodeID", bytes)
 r"""
-A 32-byte identifier for a node in the Discovery DHT
+A 32-byte identifier for a node in the Discovery DHT.
 
 .. doctest::
 

--- a/eth_typing/encoding.py
+++ b/eth_typing/encoding.py
@@ -1,7 +1,17 @@
+"""
+Types for encoding and decoding data.
+"""
+
 from typing import (
     NewType,
     Union,
 )
 
 HexStr = NewType("HexStr", str)
+"""
+A string that represents a hex encoded value.
+"""
 Primitives = Union[bytes, int, bool]
+"""
+A type that represents bytes, int or bool primitive types.
+"""

--- a/eth_typing/enums.py
+++ b/eth_typing/enums.py
@@ -1,4 +1,19 @@
+"""
+Fork names for Ethereum network upgrades.
+"""
+
+
 class ForkName:
+    """
+    Constants for each fork name.
+
+    .. doctest::
+
+        >>> from eth_typing import ForkName
+        >>> ForkName.Frontier
+        'Frontier'
+    """
+
     Frontier = "Frontier"
     Homestead = "Homestead"
     EIP150 = "EIP150"

--- a/eth_typing/evm.py
+++ b/eth_typing/evm.py
@@ -1,3 +1,7 @@
+"""
+Type definitions for the Ethereum Virtual Machine (EVM).
+"""
+
 from typing import (
     Literal,
     NewType,
@@ -10,11 +14,49 @@ from .encoding import (
 )
 
 Hash32 = NewType("Hash32", bytes)
+"""
+A 32-byte hash value.
+"""
 BlockNumber = NewType("BlockNumber", int)
+"""
+Any integer that represents a valid block number on a chain.
+"""
 BlockParams = Literal["latest", "earliest", "pending", "safe", "finalized"]
-BlockIdentifier = Union[BlockParams, BlockNumber, Hash32, HexStr, int]
+"""
+A type which specifies the block reference parameter.
 
+- ``"latest"``: The latest block.
+- ``"earliest"``: The earliest block.
+- ``"pending"``: The pending block.
+- ``"safe"``: The safe block.
+- ``"finalized"``: The finalized block.
+"""
+BlockIdentifier = Union[BlockParams, BlockNumber, Hash32, HexStr, int]
+"""
+A type that represents a block identifier value.
+
+- ``BlockParams``: A block reference parameter.
+- ``BlockNumber``: A block number integer value.
+- ``Hash32``: A 32-byte hash value.
+- ``HexStr``: A string that represents a hex value.
+- ``int``: An integer value.
+"""
 Address = NewType("Address", bytes)
+"""
+A type that contains a 32-byte canonical address.
+"""
 HexAddress = NewType("HexAddress", HexStr)
+"""
+A type that contains a hex encoded address. This is a 32-byte hex string with a prefix
+of "0x".
+"""
 ChecksumAddress = NewType("ChecksumAddress", HexAddress)
+"""
+A type that contains a eth_typing.evm.HexAddress that is formatted according to
+`ERC55 <https://github.com/ethereum/EIPs/issues/55>`_. This is a 40 character hex
+string with a prefix of "0x" and mixed case letters.
+"""
 AnyAddress = TypeVar("AnyAddress", Address, HexAddress, ChecksumAddress)
+"""
+A type that represents any type of address.
+"""

--- a/eth_typing/exceptions.py
+++ b/eth_typing/exceptions.py
@@ -1,3 +1,8 @@
+"""
+Exception types raised in web3's libraries.
+"""
+
+
 class ValidationError(Exception):
     """
     Raised when something does not pass a validation check.

--- a/eth_typing/networks.py
+++ b/eth_typing/networks.py
@@ -1,3 +1,7 @@
+"""
+Types for Ethereum network identifiers.
+"""
+
 from enum import (
     IntEnum,
 )
@@ -14,18 +18,20 @@ class ChainId(IntEnum):
     IntEnum class defining EVM-compatible network name enums as their respective
     ``ChainID`` int values.
 
-    To learn more about chain ids, see `CAIP-2 <https://github.com/ChainAgnostic/CAIPs/blob/main/CAIPs/caip-2.md>`_ for details.  # noqa: E501
+    To learn more about chain ids, see `CAIP-2 <https://github.com/ChainAgnostic/CAIPs/blob/main/CAIPs/caip-2.md>`_ for details.
 
-    The list of chain ids is available from the `ethereum-lists/chains <https://github.com/ethereum-lists/chains>`_ repository.  # noqa: E501
+    The list of chain ids is available from the `ethereum-lists/chains <https://github.com/ethereum-lists/chains>`_ repository.
 
-    For a complete list of supported enums, see `eth_typing/networks.py <https://github.com/ethereum/eth-typing/blob/f9cfaa35e2c1ac868ffe9256174aaac3b882c8d1/eth_typing/networks.py>`_.  # noqa: E501
+    For a complete list of supported enums, see `eth_typing/networks.py <https://github.com/ethereum/eth-typing/blob/f9cfaa35e2c1ac868ffe9256174aaac3b882c8d1/eth_typing/networks.py>`_.
 
     .. doctest::
 
         >>> from eth_typing import ChainId
         >>> ChainId(1)
         <ChainId.ETH: 1>
-    """
+        >>> ChainId(10)
+        <ChainId.OETH: 10>
+    """  # noqa: E501
 
     ETH = 1
     """Ethereum Mainnet"""

--- a/eth_typing/networks.py
+++ b/eth_typing/networks.py
@@ -10,16 +10,39 @@ URI = NewType("URI", str)
 
 
 class ChainId(IntEnum):
+    """
+    IntEnum class defining EVM-compatible network name enums as their respective
+    ``ChainID`` int values.
+
+    To learn more about chain ids, see `CAIP-2 <https://github.com/ChainAgnostic/CAIPs/blob/main/CAIPs/caip-2.md>`_ for details.  # noqa: E501
+
+    The list of chain ids is available from the `ethereum-lists/chains <https://github.com/ethereum-lists/chains>`_ repository.  # noqa: E501
+
+    For a complete list of supported enums, see `eth_typing/networks.py <https://github.com/ethereum/eth-typing/blob/f9cfaa35e2c1ac868ffe9256174aaac3b882c8d1/eth_typing/networks.py>`_.  # noqa: E501
+
+    .. doctest::
+
+        >>> from eth_typing import ChainId
+        >>> ChainId(1)
+        <ChainId.ETH: 1>
+    """
+
     ETH = 1
+    """Ethereum Mainnet"""
     EXP = 2
+    """Expanse"""
     ROP = 3
+    """Ropsten"""
     RIN = 4
+    """Rinkeby"""
     GOR = 5
+    """Görli"""
     KOT = 6
     TCH = 7
     UBQ = 8
     TUBQ = 9
     OETH = 10
+    """OP Mainnet"""
     META = 11
     KAL = 12
     DSTG = 13
@@ -110,6 +133,7 @@ class ChainId(IntEnum):
     SIX = 98
     POA = 99
     GNO = 100
+    """Gnosis"""
     ETI = 101
     TW3G = 102
     WLC = 103

--- a/newsfragments/65.breaking.rst
+++ b/newsfragments/65.breaking.rst
@@ -1,1 +1,0 @@
-The `eth_typing.enums` module has been renamed to `eth_typing.forks`.

--- a/newsfragments/65.breaking.rst
+++ b/newsfragments/65.breaking.rst
@@ -1,0 +1,1 @@
+The `eth_typing.enums` module has been renamed to `eth_typing.forks`.

--- a/newsfragments/81.docs.rst
+++ b/newsfragments/81.docs.rst
@@ -1,0 +1,1 @@
+Updates all modules and types with docstrings. Docs are now generated through ``autodoc``.


### PR DESCRIPTION
### What was wrong?

Documentation could use more work, it's inconsistent and missing in places.

Closes #71

### How was it fixed?

Adds `autodoc` to document modules using their docstrings.

Update modules with relevant docstrings and move old doc content to docstrings.

### Todo:

- [x] Clean up commit history

- [x] Add or update documentation related to these changes

- [x] Add entry to the [release notes](https://github.com/ethereum/eth-typing/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://img.freepik.com/premium-photo/aandachtige-blik-snake-eye-hedendaagse-surrealistische-kunst-concept-van-creativiteit-surrealisme-verbeelding-abstract-ontwerp_536572-1721.jpg)
