### PR TITLE
 Extend `ABIEvent` `inputs` with `ABIComponentIndexed`

### DIFF
--- a/eth_typing/abi.py
+++ b/eth_typing/abi.py
@@ -58,7 +58,7 @@ class ABIEvent(TypedDict):
     """Event ABI type."""
     anonymous: NotRequired[bool]
     """If True, event is anonymous. Cannot filter the event by name."""
-    inputs: NotRequired[Sequence["ABIComponent"]]
+    inputs: NotRequired[Sequence[Union["ABIComponent", "ABIComponentIndexed"]]]
     """Input components for the event."""
 
 

--- a/newsfragments/83.feature.rst
+++ b/newsfragments/83.feature.rst
@@ -1,0 +1,1 @@
+``ABIEvent`` ``inputs`` have been extended to allow ``ABIComponentIndexed`` types.


### PR DESCRIPTION
### What was wrong?

Missing type on `ABIEvent` `inputs` type makes any indexed event ABI invalid. `ABIEvent` must support the `ABIComponentIndexed` as a valid `inputs` type.

### How was it fixed?

Add ``ABIComponentIndexed`` as a valid input type for ``ABIEvent`` types.

### Todo:

- [x] Clean up commit history

- [x] Add or update documentation related to these changes

- [x] Add entry to the [release notes](https://github.com/ethereum/eth-typing/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://seattlerefined.com/resources/media2/16x9/full/1015/center/80/b4c6651e-6ab4-44f4-9f32-0abbec7c8bcc-large16x9_HotDog2.PNG)
