### PR TITLE
`v4` Deprecate ``ABIFunctionInfo`` in favor of ``ABIElementInfo``

### DIFF
--- a/eth_typing/abi.py
+++ b/eth_typing/abi.py
@@ -200,8 +200,16 @@ class ABIError(TypedDict, total=False):
 
 
 ABICallable = Union[ABIFunction, ABIConstructor, ABIFallback, ABIReceive]
+"""
+A `Union` type consisting of `ABIFunction`, `ABIConstructor`, `ABIFallback` and
+`ABIReceive` types.
+"""
+
+ABIElement = Union[ABICallable, ABIEvent, ABIError]
+"""A `Union` type consisting of `ABICallable`, `ABIEvent`, and `ABIError` types."""
 
 
+@deprecated("`ABIFunctionInfo` is deprecated, use `ABIElementInfo` instead.")
 class ABIFunctionInfo(TypedDict, total=False):
     """
     TypedDict to represent properties of an `ABIFunction`, including the function
@@ -216,8 +224,20 @@ class ABIFunctionInfo(TypedDict, total=False):
     """Function input components."""
 
 
-ABIElement = Union[ABICallable, ABIEvent, ABIError]
-"""Base type for `ABIFunction` and `ABIEvent` types."""
+class ABIElementInfo(TypedDict):
+    """
+    TypedDict to represent properties of an `ABIElement`, including the abi,
+    selector and arguments.
+    """
+
+    abi: ABIElement
+    """ABI for any `ABIElement` type."""
+    selector: HexStr
+    """Solidity `ABIElement` selector sighash."""
+    arguments: Tuple[Any, ...]
+    """`ABIElement` input components."""
+
+
 ABI = Sequence[ABIElement]
 """
 List of components representing function and event interfaces

--- a/newsfragments/86.deprecation.rst
+++ b/newsfragments/86.deprecation.rst
@@ -1,0 +1,1 @@
+Deprecate ``ABIFunctionInfo`` to be removed in the next major release.

--- a/newsfragments/86.feature.rst
+++ b/newsfragments/86.feature.rst
@@ -1,0 +1,1 @@
+TypedDict ``ABIElementInfo`` to encompass relevant information about ``ABIElement`` types. ``ABIElementInfo`` includes the function ``abi`` (``ABIElement``), ``selector`` (``HexStr``) and ``args`` (``Tuple``).


### PR DESCRIPTION
### What was wrong?

Need to deprecate ``ABIFunctionInfo`` the right way ™️ 

Related to Issue #
Closes #

### How was it fixed?

Deprecate ``ABIFunctionInfo`` in favor of ``ABIElementInfo``.
Include updated docstrings for ``ABICallable``, ``ABIElement`` types.

### Todo:

- [x] Clean up commit history

- [x] Add or update documentation related to these changes

- [x] Add entry to the [release notes](https://github.com/ethereum/eth-typing/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://res.cloudinary.com/liaison-inc/image/upload/f_auto/q_auto,w_1200/v1691518858/content/homeguide/homeguide-rodent-caught-in-wildlife-removal-trap.jpg)
