### PR TITLE
use pre-commit to run mypy locally

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,11 +43,14 @@ repos:
     -   id: mdformat
         additional_dependencies:
         -   mdformat-gfm
--   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.5.1
+-   repo: local
     hooks:
-    -   id: mypy
-        exclude: tests/
+    -   id: mypy-local
+        name: run mypy with all dev dependencies present
+        entry: python -m mypy -p eth_typing
+        language: system
+        always_run: true
+        pass_filenames: false
 -   repo: https://github.com/PrincetonUniversity/blocklint
     rev: v0.2.4
     hooks:

--- a/newsfragments/90.internal.rst
+++ b/newsfragments/90.internal.rst
@@ -1,0 +1,1 @@
+Run ``mypy`` locally rather than in a ``pre-commit`` container

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ extras_require = {
         "build>=0.9.0",
         "bumpversion>=0.5.3",
         "ipython",
+        "mypy==1.10.0",
         "pre-commit>=3.4.0",
         "tox>=4.0.0",
         "twine",

--- a/tox.ini
+++ b/tox.ini
@@ -35,6 +35,7 @@ allowlist_externals=make,pre-commit
 
 [testenv:py{38,39,310,311,312}-lint]
 deps=pre-commit
+extras=dev
 commands=
     pre-commit install
     pre-commit run --all-files --show-diff-on-failure


### PR DESCRIPTION
### What was wrong?

Running `mypy` in a `pre-commit` venv misses local context.

### How was it fixed?

Use a `pre-commit` hook to run the locally-installed `mypy` instead. Fortunately, no new problems.

### Todo:

- [x] Clean up commit history

- [x] Add or update documentation related to these changes

- [x] Add entry to the [release notes](https://github.com/ethereum/eth-typing/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/user-attachments/assets/9e81963f-0e05-438e-bee8-313eb59893ce)
