### PR TITLE
bugfix: ABIEvent inputs should include indexed property

### DIFF
--- a/eth_typing/abi.py
+++ b/eth_typing/abi.py
@@ -58,7 +58,7 @@ class ABIEvent(TypedDict):
     """Event ABI type."""
     anonymous: NotRequired[bool]
     """If True, event is anonymous. Cannot filter the event by name."""
-    inputs: NotRequired[Sequence["ABIComponent"]]
+    inputs: NotRequired[Sequence["ABIComponentIndexed"]]
     """Input components for the event."""
 
 

--- a/newsfragments/92.bugfix.rst
+++ b/newsfragments/92.bugfix.rst
@@ -1,0 +1,1 @@
+``ABIEvent`` should use ``ABIComponentIndexed`` instead of ``ABIComponent`` as the type for ``inputs``.


### PR DESCRIPTION
### What was wrong?

Closes #91

### How was it fixed?

### Todo:

- [x] Add entry to the [release notes](https://github.com/ethereum/eth-typing/blob/main/newsfragments/README.md)

#### Cute Animal Picture

```
 /\_/\  
( o.o ) 
 > ^ <
```