### PR TITLE
bugfix: Mark `name` of `ABIComponent` as `NotRequired`

### DIFF
--- a/eth_typing/abi.py
+++ b/eth_typing/abi.py
@@ -30,10 +30,10 @@ class ABIComponent(TypedDict):
     TypedDict representing an `ABIElement` component.
     """
 
-    name: str
-    """Name of the component."""
     type: str
     """Type of the component."""
+    name: NotRequired[str]
+    """Name of the component."""
     components: NotRequired[Sequence["ABIComponent"]]
     """List of nested `ABI` components for ABI types."""
 

--- a/newsfragments/95.bugfix.rst
+++ b/newsfragments/95.bugfix.rst
@@ -1,0 +1,1 @@
+Set name as optional for ``ABIComponent`` type.


### PR DESCRIPTION
### What was wrong?

The name field of an ABI event or function is optional.

Related to https://github.com/ethereum/eth-utils/pull/299

### How was it fixed?

Add `NotRequired` to the `ABIComponent.name` type.

### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/ethereum/eth-typing/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.ytimg.com/vi/YlSsag8LS28/maxresdefault.jpg)
