### PR TITLE
Change versioned in eth_typing/__init__.py from auto to manual

### DIFF
--- a/eth_typing/__init__.py
+++ b/eth_typing/__init__.py
@@ -86,4 +86,4 @@ __all__ = (
     "ChainId",
 )
 
-__version__ = __version("eth-typing")
+__version__ = "5.2.1"  # Change this in every new version.


### PR DESCRIPTION
Change auto version before build.

## What was wrong?

During Debian packaging, this call fails because the package metadata is not available in the build environment.

## How was it fixed?

Changing versioned from auto to manual.

