### PR TITLE
Add Osaka, Amsterdam, and Bogota to ForkName enum

### DIFF
--- a/eth_typing/enums.py
+++ b/eth_typing/enums.py
@@ -31,3 +31,6 @@ class ForkName:
     Shanghai = "Shanghai"
     Cancun = "Cancun"
     Prague = "Prague"
+    Osaka = "Osaka"
+    Amsterdam = "Amsterdam"
+    Bogota = "Bogota"

--- a/newsfragments/100.feature.rst
+++ b/newsfragments/100.feature.rst
@@ -1,0 +1,1 @@
+Add Osaka, Bogota, and Amsterdam to ForkName enum


### PR DESCRIPTION
### What was wrong?
Needed to add Osaka, Amsterdam, and Bogota to the ForkName enum for completeness

### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/ethereum/eth-typing/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://images.squarespace-cdn.com/content/v1/579b930ecd0f68622188c183/1564254756428-6XXFDH3JE4469F92NR9C/pet-travel.png)
